### PR TITLE
Bug fix when running with RETURN_ERR=yes

### DIFF
--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -263,4 +263,4 @@ else
 fi
 run_all_benchmarks ${list[@]};
 collate_and_print_results ${list[@]};
-if [ "$nfail" > 0 ] && [ "$RETURN_ERR" == "yes" ]; then exit 1; fi
+if [ "$nfail" -gt 0 ] && [ "$RETURN_ERR" == "yes" ]; then exit 1; fi


### PR DESCRIPTION
Syntax for checking `$nfail > 0` was incorrect

`[ "$nfail" > 0 ]` just writes the value of `nfail` to the file `0`