### PR TITLE
Remove LFS filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*_????? filter=lfs diff=lfs merge=lfs -text
-*.ref filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Git LFS is no longer used, so this PR removes .gitattributes containing filters for the dump files.