### PR TITLE
Fix mac redirect

### DIFF
--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -164,7 +164,8 @@ run_code()
   walltime=`head -1 $timelog`;
   walltime=${walltime/real/};
   # check differences
-  ./diffdumps ${reffile/.ref/} ${reffile} $tol > $difflog
+  # "| cat" is a workaround for macOS: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102992
+  ./diffdumps ${reffile/.ref/} ${reffile} $tol | cat > $difflog
   check=`grep FILES $difflog`
   if [ "$check" == " FILES ARE IDENTICAL " ]; then
      echo "$datetagiso $walltime" > $benchlog

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -165,9 +165,10 @@ run_code()
   walltime=${walltime/real/};
   # check differences
   # "| cat" is a workaround for macOS: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102992
-  ./diffdumps ${reffile/.ref/} ${reffile} $tol | cat > $difflog
-  check=`grep FILES $difflog`
-  if [ "$check" == " FILES ARE IDENTICAL " ]; then
+  diff=`./diffdumps ${reffile/.ref/} ${reffile} $tol`;
+  ndiff=$?
+  echo "$diff" > $difflog
+  if [ $ndiff -eq 0 ]; then
      echo "$datetagiso $walltime" > $benchlog
      echo "$datetagiso $walltime" >> $perflog
   else


### PR DESCRIPTION
Fixes #14 by checking diffdumps using exit code rather than searching for a string.

Workaround for redirecting fortran output into a file by piping to `cat` first:
```
./diffdumps ${reffile/.ref/} ${reffile} $tol | cat > $difflog
```

Needs https://github.com/danieljprice/phantom/pull/237