### PR TITLE
Fix hashlist for commonenv benchmark

### DIFF
--- a/commonenv/.hashlist
+++ b/commonenv/.hashlist
@@ -1,2 +1,2 @@
-commonenv_00310
-commonenv_00310.ref
+c7456f0d9d4d47b425c65510e039c9f70c94a153  commonenv_00310
+e918a76ff05d1a93a096dbdd7e08a55b1788ef7c  commonenv_00311.ref


### PR DESCRIPTION
Fixes some small errors in #12. The hash list was missing the hashes, and pointed to the wrong filename.